### PR TITLE
use kubeconfig from manager for worker pool.

### DIFF
--- a/pkg/spec/controller/workers/worker_pool.go
+++ b/pkg/spec/controller/workers/worker_pool.go
@@ -26,10 +26,7 @@ type WorkerPool struct {
 
 // AddK8sWorkerPool adds k8s workers pool to the manager and returns it.
 func AddWorkerPool(log logr.Logger, workpoolSize int, manager ctrl.Manager) (*WorkerPool, error) {
-	config, err := rest.InClusterConfig() // creates the in-cluster config
-	if err != nil {
-		return nil, fmt.Errorf("failed to get in cluster kubeconfig - %w", err)
-	}
+	config := manager.GetConfig()
 
 	// for impersonation workers we have additional workers, one per impersonated user.
 	workerPool := &WorkerPool{


### PR DESCRIPTION
We should use the same kubeconfig from the manager, instead of getting new one from in-cluster, because in some cases, we may want to override the by specify `--kubeconfig` or `KUBECONFIG` env, then the  in-cluster kubeconfig will be different.

Signed-off-by: morvencao <lcao@redhat.com>